### PR TITLE
Nudgarr v5.0.3 — Alpine 3.24 Base and OS Security Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Nudgarr are documented here.
 
 ---
 
+## v5.0.3
+
+**Alpine base and OS package security updates**
+
+- **Security:** Pin Docker base to `python:3.12.13-alpine3.24` (Alpine 3.24 ships patched `openssl` 3.5.7-r0 and `sqlite-libs` 3.53.2-r0).
+- **Security:** Run `apk update && apk upgrade` at build time so fixable Alpine CVEs are pulled on rebuild.
+- **Security:** Upgrade build-time `pip` to >= 26.1.2 (addresses pip CVEs flagged on older bundled versions).
+
+---
+
 ## v5.0.2
 
 **Dependency and container security updates**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Nudgarr is a lightweight project -- the goal is to keep it that way. If you're c
 
 ## Project structure
 
-As of v5.0.0, Nudgarr uses a SQLite database for all persistence via the `nudgarr/db/` package and an Alpine.js single-file frontend. Patch releases (v5.0.2, etc.) are listed at the top of `CHANGELOG.md`; `constants.py` `VERSION` must match the latest changelog heading (enforced by `validate.py`).
+As of v5.0.0, Nudgarr uses a SQLite database for all persistence via the `nudgarr/db/` package and an Alpine.js single-file frontend. Patch releases (v5.0.3, etc.) are listed at the top of `CHANGELOG.md`; `constants.py` `VERSION` must match the latest changelog heading (enforced by `validate.py`).
 
 ```
 nudgarr/                    <- Python package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.12-alpine
+FROM python:3.12.13-alpine3.24
 
-# Upgrade all Alpine packages to pull latest security patches at build time
-RUN apk upgrade --no-cache
+# Refresh Alpine packages (openssl, sqlite-libs, busybox, etc.) at build time
+RUN apk update && apk upgrade --no-cache
 
 # Install dependencies including su-exec for privilege dropping
 COPY requirements.txt /app/requirements.txt
-RUN python -m pip install --no-cache-dir --upgrade "pip>=26.1" \
+RUN python -m pip install --no-cache-dir --upgrade "pip>=26.1.2" \
     && pip install --no-cache-dir --no-compile -r /app/requirements.txt \
     && apk add --no-cache su-exec
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Images are available on **Docker Hub** and **GitHub Container Registry (GHCR)**.
 | Docker Hub | `mmagtech/nudgarr:latest` |
 | GHCR | `ghcr.io/mmagtech/nudgarr:latest` |
 
-**Tags:** `latest` · `v5.0.2` · `5.0.2`
+**Tags:** `latest` · `v5.0.3` · `5.0.3`
 
 1. Copy `.env.example` to `.env` and fill in your values
 2. Run `docker compose up -d`
@@ -126,6 +126,8 @@ Run on your LAN only. For remote access use a VPN (Tailscale, WireGuard) or a re
 ## Upgrade notes
 
 **v5.0.0** is a full frontend rewrite to Alpine.js with a sidebar navigation layout. The 14-file vanilla JS split is replaced by a single `app.js` and `ui.html`. The horizontal tab bar is gone -- navigation is now a sidebar with Monitor, Configure, and System groups. History, Imports, CF Score, and Exclusions are consolidated into a single Library panel with a view switcher. CF Score can now be toggled independently per app (Radarr/Sonarr) and per instance. No config changes required. Pull the new image and restart. New config keys are injected automatically on first start.
+
+**v5.0.3** is a patch release: Docker base pinned to Alpine 3.24 with build-time `apk upgrade` for fixable OS package CVEs (openssl, sqlite-libs), and pip upgraded to >= 26.1.2. No config changes required. Pull the new image and restart.
 
 **v5.0.2** is a patch release: dependency bumps (`flask`, `requests`, `urllib3`) and Docker build upgrades `pip` to address reported CVEs. No config changes required. Pull the new image and restart.
 

--- a/nudgarr/constants.py
+++ b/nudgarr/constants.py
@@ -10,7 +10,7 @@ No imports from within the nudgarr package — stdlib only.
 import os
 from typing import Any, Dict
 
-VERSION = "5.0.2"
+VERSION = "5.0.3"
 
 CONFIG_FILE = os.getenv("CONFIG_FILE", "/config/nudgarr-config.json")
 DB_FILE = os.getenv("DB_FILE", "/config/nudgarr.db")


### PR DESCRIPTION
Patch release after v5.0.2. Pins the Docker base to python:3.12.13-alpine3.24 and runs apk update/upgrade at build time so fixable Alpine CVEs (openssl, sqlite-libs) are pulled on rebuild. Upgrades build-time pip to >= 26.1.2. No app or config changes — redeploy / restart only.

Dockerfile
- FROM python:3.12.13-alpine3.24 (was python:3.12-alpine)
- apk update && apk upgrade --no-cache
- pip>=26.1.2 during image build

Version / docs
- VERSION 5.0.3 in nudgarr/constants.py
- CHANGELOG.md, README.md, CONTRIBUTING.md updated